### PR TITLE
Add logging and environment-based Discord credentials

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,14 @@
+# Usage
+
+Buster requires a few environment variables to run:
+
+- `DISCORD_TOKEN` – Discord bot token used to connect to the API.
+- `DISCORD_APP_ID` – Application ID for slash command registration.
+- `BUSTER_LOG_LEVEL` – Optional log level (default is `INFO`).
+
+Install dependencies and run the bot:
+
+```bash
+pip install -r requirements.txt
+python -m buster.discord_bot
+```

--- a/src/buster/__init__.py
+++ b/src/buster/__init__.py
@@ -1,0 +1,15 @@
+import logging
+import os
+
+
+def setup_logging() -> None:
+    """Configure root logger with level and format."""
+    level_name = os.getenv("BUSTER_LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(name)s [%(levelname)s] %(message)s",
+    )
+
+
+setup_logging()

--- a/src/buster/discord_bot.py
+++ b/src/buster/discord_bot.py
@@ -1,0 +1,47 @@
+"""Minimal Discord bot entry point."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import discord
+
+logger = logging.getLogger(__name__)
+
+
+def get_credentials() -> tuple[str, str]:
+    """Return Discord token and application ID from environment."""
+    token = os.getenv("DISCORD_TOKEN")
+    app_id = os.getenv("DISCORD_APP_ID")
+    missing = []
+    if not token:
+        missing.append("DISCORD_TOKEN")
+    if not app_id:
+        missing.append("DISCORD_APP_ID")
+    if missing:
+        logger.error(
+            "missing environment variables",
+            extra={"missing": missing},
+        )
+        raise RuntimeError(f"Missing credentials: {', '.join(missing)}")
+    return token, app_id
+
+
+class BusterBot(discord.Client):
+    async def on_ready(self) -> None:  # type: ignore[override]
+        logger.info("connected", extra={"user": str(self.user)})
+
+
+def main() -> None:
+    token, _app_id = get_credentials()
+    intents = discord.Intents.default()
+    client = BusterBot(intents=intents)
+    try:
+        client.run(token)
+    except Exception:  # pragma: no cover - simple run wrapper
+        logger.exception("bot run failed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- set up logging in `buster` package
- add Discord bot that reads credentials from environment variables
- document necessary environment variables in Usage docs

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849a292dc5c83238f37a2236c18805f