### PR TITLE
Add CI workflow and docs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run flake8
+        run: flake8
+      - name: Run pytest
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Install the dependencies with:
 pip install -r requirements.txt
 ```
 
+See [docs/usage.md](docs/usage.md) for setup instructions and more details on running the bot.
+
 ## Running Checks
 
 Before submitting changes, run the linters and tests:
@@ -79,6 +81,7 @@ The project follows PEP8 with a 100 character line limit.
 ## Deployment
 
 The production bot is intended to run in a containerized environment. CI/CD is
-handled through GitHub Actions which will execute `flake8` and `pytest` on each
-commit.
+handled through GitHub Actions. The workflow defined in
+`.github/workflows/ci.yml` runs `flake8` and `pytest` on every push and pull
+request.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,13 @@
+# Usage
+
+To run the Buster prototype you need Python 3.11 or newer.
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Configure your Discord bot token and other settings as environment variables.
+3. Start the bot (this repository does not yet include the implementation).
+
+The `docs/architecture.md` will provide additional information about how the
+components fit together once completed.


### PR DESCRIPTION
## Summary
- set `max-line-length` in `.flake8`
- add GitHub Actions workflow running flake8 and pytest
- document setup instructions
- mention CI workflow in README and link to docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a29231b0832396ba644e32ea54d1