### PR TITLE
Add Buster package stubs

### DIFF
--- a/src/buster/__init__.py
+++ b/src/buster/__init__.py
@@ -1,0 +1,6 @@
+"""Buster package for automating OFAC report submissions."""
+
+__all__ = [
+    "BusterOrchestrator",
+    "ReportCompiler",
+]

--- a/src/buster/best_practices/__init__.py
+++ b/src/buster/best_practices/__init__.py
@@ -1,0 +1,1 @@
+"""Best practice scoring subpackage."""

--- a/src/buster/best_practices/guidelines.py
+++ b/src/buster/best_practices/guidelines.py
@@ -1,0 +1,6 @@
+"""Reference best-practice documentation and tips."""
+
+GUIDELINES = [
+    "Include all relevant messages",
+    "Ensure evidence links are accessible",
+]

--- a/src/buster/best_practices/scoring.py
+++ b/src/buster/best_practices/scoring.py
@@ -1,0 +1,6 @@
+"""Apply scoring rules to evaluate report completeness."""
+
+
+def score_report(data: dict) -> int:
+    """Return a placeholder score for the report data."""
+    return len(data.get("messages", []))

--- a/src/buster/compiler/__init__.py
+++ b/src/buster/compiler/__init__.py
@@ -1,0 +1,1 @@
+"""Compiler subpackage."""

--- a/src/buster/compiler/report_compiler.py
+++ b/src/buster/compiler/report_compiler.py
@@ -1,0 +1,9 @@
+"""Build report data from messages and linked content."""
+
+
+class ReportCompiler:
+    """Fetches evidence and assembles the report payload."""
+
+    def compile(self, messages: list[str]) -> dict:
+        """Return a minimal report structure from the provided messages."""
+        return {"messages": messages}

--- a/src/buster/discord_bot.py
+++ b/src/buster/discord_bot.py
@@ -1,0 +1,10 @@
+"""Discord bot entry point and command registration."""
+
+
+class DiscordBot:
+    """Register Discord commands and handle bot lifecycle."""
+
+    def run(self) -> None:
+        """Placeholder method to start the bot."""
+        # Real implementation would connect to Discord here
+        pass

--- a/src/buster/orchestrator.py
+++ b/src/buster/orchestrator.py
@@ -1,0 +1,14 @@
+"""Core logic for coordinating report compilation and submission."""
+
+from .compiler.report_compiler import ReportCompiler
+
+
+class BusterOrchestrator:
+    """Coordinates message intake and dispatches work to other agents."""
+
+    def __init__(self) -> None:
+        self.compiler = ReportCompiler()
+
+    def handle_report_command(self, messages: list[str]) -> dict:
+        """Compile a report from messages and return structured data."""
+        return self.compiler.compile(messages)

--- a/src/buster/validation/__init__.py
+++ b/src/buster/validation/__init__.py
@@ -1,0 +1,1 @@
+"""Validation subpackage."""

--- a/src/buster/validation/data_validation.py
+++ b/src/buster/validation/data_validation.py
@@ -1,0 +1,11 @@
+"""Utilities for checking report data against the schema."""
+
+from .schema import REPORT_SCHEMA
+
+
+def validate_report(data: dict) -> bool:
+    """Placeholder validation that ensures required fields exist."""
+    for field in REPORT_SCHEMA["required"]:
+        if field not in data:
+            return False
+    return True

--- a/src/buster/validation/schema.py
+++ b/src/buster/validation/schema.py
@@ -1,0 +1,9 @@
+"""JSON schema definitions for report validation."""
+
+REPORT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "messages": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["messages"],
+}


### PR DESCRIPTION
## Summary
- scaffold `buster` package under `src` with submodules
- implement minimal stubs for orchestrator, compiler, validation, and best-practice logic

## Testing
- `flake8 && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a28e3e90832395b9a1ee2b8222ec