### PR TITLE
Add minimal module loading tests

### DIFF
--- a/src/buster/__init__.py
+++ b/src/buster/__init__.py
@@ -2,6 +2,7 @@
 import logging
 import os
 
+
 def setup_logging() -> None:
     """Configure root logger with level and format."""
     level_name = os.getenv("BUSTER_LOG_LEVEL", "INFO").upper()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the src directory is on the path for imports
+SRC_DIR = Path(__file__).resolve().parents[1] / 'src'
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))

--- a/tests/test_best_practices.py
+++ b/tests/test_best_practices.py
@@ -1,0 +1,6 @@
+import importlib
+
+
+def test_best_practices_import():
+    module = importlib.import_module('buster.best_practices.scoring')
+    assert hasattr(module, 'score_report')

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,0 +1,6 @@
+import importlib
+
+
+def test_compiler_import():
+    module = importlib.import_module('buster.compiler.report_compiler')
+    assert hasattr(module, 'ReportCompiler')

--- a/tests/test_data_validation.py
+++ b/tests/test_data_validation.py
@@ -1,0 +1,6 @@
+import importlib
+
+
+def test_data_validation_import():
+    module = importlib.import_module('buster.validation.data_validation')
+    assert hasattr(module, 'validate_report')

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,6 @@
+import importlib
+
+
+def test_orchestrator_import():
+    module = importlib.import_module('buster.orchestrator')
+    assert hasattr(module, 'BusterOrchestrator')


### PR DESCRIPTION
## Summary
- create simple tests ensuring each Buster module imports
- fix style issues and add test helper to load `src` modules

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ae683ef483239359dd931399073a