### PR TITLE
Add docs folder and reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ pip install -r requirements.txt
 ```
 
 See [docs/usage.md](docs/usage.md) for setup instructions and more details on running the bot.
+The high-level design is documented in [docs/architecture.md](docs/architecture.md),
+and the placeholder OFAC schema can be found at [docs/ofac_schema.json](docs/ofac_schema.json).
 
 ## Running Checks
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,6 +4,12 @@ This repository follows the canonical layout described in `AGENTS.md`.
 The structure keeps orchestrator, compiler, validation and best practice
 logic modular while grouping them under a single package.
 
+At a high level the bot is driven by the **BusterOrchestrator**. It receives
+commands from Discord and dispatches them to the `ReportCompiler` to gather
+messages and linked content. The resulting payload is checked by the
+`DataValidation` component before being scored with the `BestPractices`
+module and finally submitted to OFAC.
+
 ```text
 src/
   buster/

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,5 +19,4 @@ Install dependencies and run the bot:
     python -m buster.discord_bot
     ```
 
-The `docs/architecture.md` will provide additional information about how the
-components fit together once completed.
+The [architecture documentation](architecture.md) provides more details on how the components fit together

--- a/src/buster/__init__.py
+++ b/src/buster/__init__.py
@@ -2,6 +2,7 @@
 import logging
 import os
 
+
 def setup_logging() -> None:
     """Configure root logger with level and format."""
     level_name = os.getenv("BUSTER_LOG_LEVEL", "INFO").upper()


### PR DESCRIPTION
## Summary
- document the architecture and usage
- add placeholder OFAC schema
- refer to docs from README
- fix style issues in `buster/__init__.py`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ae691a2c8323b2c1696ab74190e0