### PR TITLE
Add CI workflow and flake8 config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,8 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
       - name: Run flake8
         run: flake8
       - name: Run pytest
-        run: pytest -q
+        run: pytest

--- a/src/buster/__init__.py
+++ b/src/buster/__init__.py
@@ -2,6 +2,7 @@
 import logging
 import os
 
+
 def setup_logging() -> None:
     """Configure root logger with level and format."""
     level_name = os.getenv("BUSTER_LOG_LEVEL", "INFO").upper()


### PR DESCRIPTION
## Summary
- enforce line length 100 using `.flake8`
- run `pip install -r requirements.txt`, `flake8`, and `pytest` in CI
- clean up `__init__.py` to pass flake8

## Testing
- `pip install -r requirements.txt`
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6849ae69d768832396d220497935365d