### PR TITLE
Add structured logging and env var docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ pip install -r requirements.txt
 
 See [docs/usage.md](docs/usage.md) for setup instructions and more details on running the bot.
 
+## Environment Variables
+
+The bot reads its configuration from environment variables:
+
+- `DISCORD_TOKEN` – Discord bot token used for authentication.
+- `DISCORD_APP_ID` – Application ID for registering slash commands.
+- `BUSTER_LOG_LEVEL` – Optional logging level (defaults to `INFO`).
+
 ## Running Checks
 
 Before submitting changes, run the linters and tests:

--- a/src/buster/__init__.py
+++ b/src/buster/__init__.py
@@ -1,15 +1,14 @@
 """Buster package for automating OFAC report submissions."""
+
 import logging
 import os
+
 
 def setup_logging() -> None:
     """Configure root logger with level and format."""
     level_name = os.getenv("BUSTER_LOG_LEVEL", "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s %(name)s [%(levelname)s] %(message)s",
-    )
+    logging.basicConfig(level=level, format="%(asctime)s %(name)s [%(levelname)s] %(message)s")
 
 
 setup_logging()

--- a/src/buster/discord_bot.py
+++ b/src/buster/discord_bot.py
@@ -7,6 +7,11 @@ import os
 
 import discord
 
+logging.basicConfig(
+    level=getattr(logging, os.getenv("BUSTER_LOG_LEVEL", "INFO").upper(), logging.INFO),
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- set up structured logging in `discord_bot.py`
- clean up root package init
- document environment variables in README

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ae6adf3883239418947b3a0690fa