### PR TITLE
Add compiler and validation tests

### DIFF
--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -4,3 +4,10 @@ import importlib
 def test_compiler_import():
     module = importlib.import_module('buster.compiler.report_compiler')
     assert hasattr(module, 'ReportCompiler')
+
+
+def test_compile_returns_messages_dict():
+    compiler = importlib.import_module(
+        'buster.compiler.report_compiler'
+    ).ReportCompiler()
+    assert compiler.compile(["msg"]) == {"messages": ["msg"]}

--- a/tests/test_data_validation.py
+++ b/tests/test_data_validation.py
@@ -4,3 +4,17 @@ import importlib
 def test_data_validation_import():
     module = importlib.import_module('buster.validation.data_validation')
     assert hasattr(module, 'validate_report')
+
+
+def test_validate_report_returns_true_for_valid_data():
+    validate_report = importlib.import_module(
+        'buster.validation.data_validation'
+    ).validate_report
+    assert validate_report({"messages": ["m"]}) is True
+
+
+def test_validate_report_returns_false_for_invalid_data():
+    validate_report = importlib.import_module(
+        'buster.validation.data_validation'
+    ).validate_report
+    assert validate_report({"other": "x"}) is False


### PR DESCRIPTION
## Summary
- extend compiler tests to check compile output
- add validation tests for valid and invalid data

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c02c34908323b8fc3b8f672cfa3a