### PR TITLE
Fix documentation punctuation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,4 +19,4 @@ Install dependencies and run the bot:
     python -m buster.discord_bot
     ```
 
-The [architecture documentation](architecture.md) provides more details on how the components fit together
+The [architecture documentation](architecture.md) provides more details on how the components fit together.


### PR DESCRIPTION
## Summary
- fix missing period in `usage.md`

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849c02cec7883238ed4593cd6fb7c23