### PR TITLE
Add logging to orchestrator

### DIFF
--- a/src/buster/orchestrator.py
+++ b/src/buster/orchestrator.py
@@ -1,6 +1,11 @@
 """Core logic for coordinating report compilation and submission."""
 
+import logging
+
 from .compiler.report_compiler import ReportCompiler
+
+
+logger = logging.getLogger(__name__)
 
 
 class BusterOrchestrator:
@@ -11,4 +16,7 @@ class BusterOrchestrator:
 
     def handle_report_command(self, messages: list[str]) -> dict:
         """Compile a report from messages and return structured data."""
-        return self.compiler.compile(messages)
+        logger.info("received report command", extra={"message_count": len(messages)})
+        result = self.compiler.compile(messages)
+        logger.info("report command compiled", extra={"return_value": result})
+        return result


### PR DESCRIPTION
## Summary
- create a logger in `orchestrator.py`
- log message count and output when handling report commands

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c9671e348323a272f6ea43550719