### PR TITLE
Add test for BusterOrchestrator

### DIFF
--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -4,3 +4,8 @@ import importlib
 def test_orchestrator_import():
     module = importlib.import_module('buster.orchestrator')
     assert hasattr(module, 'BusterOrchestrator')
+
+
+def test_handle_report_command_returns_messages_dict():
+    orchestrator = importlib.import_module('buster.orchestrator').BusterOrchestrator()
+    assert orchestrator.handle_report_command(["a"]) == {"messages": ["a"]}


### PR DESCRIPTION
## Summary
- extend orchestrator tests with handle_report_command case

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c96790f8832398b0f155c1e00999