### PR TITLE
Implement jsonschema validation

### DIFF
--- a/docs/ofac_schema.json
+++ b/docs/ofac_schema.json
@@ -1,8 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "OFACReport",
-  "description": "Placeholder schema for an OFAC violation report.",
+  "description": "Schema for an OFAC violation report.",
   "type": "object",
-  "properties": {},
-  "required": []
+  "properties": {
+    "messages": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  },
+  "required": ["messages"]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ discord.py>=2.3
 requests>=2.31
 flake8>=7.0
 pytest>=8.2
+jsonschema>=4.19

--- a/src/buster/validation/data_validation.py
+++ b/src/buster/validation/data_validation.py
@@ -1,11 +1,14 @@
 """Utilities for checking report data against the schema."""
 
+from jsonschema import ValidationError, validate
+
 from .schema import REPORT_SCHEMA
 
 
 def validate_report(data: dict) -> bool:
-    """Placeholder validation that ensures required fields exist."""
-    for field in REPORT_SCHEMA["required"]:
-        if field not in data:
-            return False
+    """Return True when the report dictionary conforms to the OFAC schema."""
+    try:
+        validate(instance=data, schema=REPORT_SCHEMA)
+    except ValidationError:
+        return False
     return True

--- a/src/buster/validation/schema.py
+++ b/src/buster/validation/schema.py
@@ -1,9 +1,11 @@
 """JSON schema definitions for report validation."""
 
-REPORT_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "messages": {"type": "array", "items": {"type": "string"}},
-    },
-    "required": ["messages"],
-}
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+SCHEMA_PATH = Path(__file__).resolve().parents[3] / "docs" / "ofac_schema.json"
+
+with SCHEMA_PATH.open() as f:
+    REPORT_SCHEMA: dict = json.load(f)

--- a/tests/test_data_validation.py
+++ b/tests/test_data_validation.py
@@ -1,20 +1,25 @@
 import importlib
 
 
+def _get_validate():
+    return importlib.import_module('buster.validation.data_validation').validate_report
+
+
 def test_data_validation_import():
     module = importlib.import_module('buster.validation.data_validation')
     assert hasattr(module, 'validate_report')
 
 
 def test_validate_report_returns_true_for_valid_data():
-    validate_report = importlib.import_module(
-        'buster.validation.data_validation'
-    ).validate_report
+    validate_report = _get_validate()
     assert validate_report({"messages": ["m"]}) is True
 
 
-def test_validate_report_returns_false_for_invalid_data():
-    validate_report = importlib.import_module(
-        'buster.validation.data_validation'
-    ).validate_report
+def test_validate_report_returns_false_for_wrong_type():
+    validate_report = _get_validate()
+    assert validate_report({"messages": "m"}) is False
+
+
+def test_validate_report_returns_false_for_missing_field():
+    validate_report = _get_validate()
     assert validate_report({"other": "x"}) is False


### PR DESCRIPTION
## Summary
- load canonical OFAC JSON schema from `docs/ofac_schema.json`
- validate reports with the `jsonschema` library
- expand tests to cover wrong types and missing fields
- add `jsonschema` dependency

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae9c2db388323a9e511a15eb32c0b