### PR TITLE
Enable JSON-formatted logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The bot reads its configuration from environment variables:
 
 - `DISCORD_TOKEN` – Discord bot token used for authentication.
 - `DISCORD_APP_ID` – Application ID for registering slash commands.
-- `BUSTER_LOG_LEVEL` – Optional logging level (defaults to `INFO`).
+- `BUSTER_LOG_LEVEL` – Optional logging level for JSON logs (defaults to `INFO`).
 
 ## Running Checks
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,7 @@ Buster requires a few environment variables to run:
 
 - `DISCORD_TOKEN` – Discord bot token used to connect to the API.
 - `DISCORD_APP_ID` – Application ID for slash command registration.
-- `BUSTER_LOG_LEVEL` – Optional log level (default is `INFO`).
+- `BUSTER_LOG_LEVEL` – Optional log level for JSON logs (default is `INFO`).
 
 3. Start the bot (this repository does not yet include the implementation).
 Install dependencies and run the bot:

--- a/src/buster/__init__.py
+++ b/src/buster/__init__.py
@@ -1,14 +1,43 @@
 """Buster package for automating OFAC report submissions."""
 
+from __future__ import annotations
+
+import json
 import logging
 import os
+from typing import Any
+
+
+DEFAULT_ATTRS = set(logging.LogRecord(None, 0, "", 0, "", (), None).__dict__).union(
+    {"message", "asctime"}
+)
+
+
+class JsonFormatter(logging.Formatter):
+    """Format log records as JSON strings."""
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - short method
+        base: dict[str, Any] = {
+            "time": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        for key, value in record.__dict__.items():
+            if key not in DEFAULT_ATTRS:
+                base[key] = value
+        return json.dumps(base)
 
 
 def setup_logging() -> None:
-    """Configure root logger with level and format."""
+    """Configure root logger with JSON output."""
     level_name = os.getenv("BUSTER_LOG_LEVEL", "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
-    logging.basicConfig(level=level, format="%(asctime)s %(name)s [%(levelname)s] %(message)s")
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(level)
 
 
 setup_logging()

--- a/src/buster/orchestrator.py
+++ b/src/buster/orchestrator.py
@@ -14,9 +14,15 @@ class BusterOrchestrator:
     def __init__(self) -> None:
         self.compiler = ReportCompiler()
 
-    def handle_report_command(self, messages: list[str]) -> dict:
+    def handle_report_command(self, user_id: str, messages: list[str]) -> dict:
         """Compile a report from messages and return structured data."""
-        logger.info("received report command", extra={"message_count": len(messages)})
+        logger.info(
+            "received report command",
+            extra={"user_id": user_id, "message_count": len(messages)},
+        )
         result = self.compiler.compile(messages)
-        logger.info("report command compiled", extra={"return_value": result})
+        logger.info(
+            "report command compiled",
+            extra={"user_id": user_id, "message_count": len(messages)},
+        )
         return result

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -8,4 +8,4 @@ def test_orchestrator_import():
 
 def test_handle_report_command_returns_messages_dict():
     orchestrator = importlib.import_module('buster.orchestrator').BusterOrchestrator()
-    assert orchestrator.handle_report_command(["a"]) == {"messages": ["a"]}
+    assert orchestrator.handle_report_command("u1", ["a"]) == {"messages": ["a"]}


### PR DESCRIPTION
## Summary
- configure logging to output JSON records
- include user IDs and message counts in orchestrator logs
- update README and usage docs
- adjust tests for new orchestrator API

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ae9cd595c832383317a9c95047408