### PR TITLE
Add Docker container and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: pip install -r requirements.txt
+      - name: Build Docker image
+        run: docker build -t buster .
       - name: Run flake8
-        run: flake8
+        run: docker run --rm --entrypoint flake8 buster
       - name: Run pytest
-        run: pytest
+        run: docker run --rm --entrypoint pytest buster

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT ["python", "-m", "buster.discord_bot"]

--- a/README.md
+++ b/README.md
@@ -95,3 +95,23 @@ handled through GitHub Actions. The workflow defined in
 `.github/workflows/ci.yml` runs `flake8` and `pytest` on every push and pull
 request.
 
+
+## Container Usage
+
+Build the Docker image:
+
+```bash
+docker build -t buster .
+```
+
+Run the bot from the image (set your credentials as environment variables):
+
+```bash
+docker run --rm -e DISCORD_TOKEN=TOKEN -e DISCORD_APP_ID=APPID buster
+```
+
+To execute the test suite inside the container use:
+
+```bash
+docker run --rm --entrypoint pytest buster
+```


### PR DESCRIPTION
## Summary
- provide Dockerfile for running `buster.discord_bot`
- update GitHub Actions workflow to lint and test inside the Docker image
- document how to use the container

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae9cc1c688323ba5a851740dfa76a