### PR TITLE
Add report command and OFAC submission flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ The bot reads its configuration from environment variables:
 - `DISCORD_TOKEN` – Discord bot token used for authentication.
 - `DISCORD_APP_ID` – Application ID for registering slash commands.
 - `BUSTER_LOG_LEVEL` – Optional logging level (defaults to `INFO`).
+- `OFAC_API_URL` – HTTP endpoint used to submit validated reports.
+
+## Discord Commands
+
+The bot exposes a single slash command:
+
+- `/report` – collects the latest messages in the channel and submits them as an
+  OFAC report.
 
 ## Running Checks
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,8 +11,9 @@ Buster requires a few environment variables to run:
 - `DISCORD_TOKEN` – Discord bot token used to connect to the API.
 - `DISCORD_APP_ID` – Application ID for slash command registration.
 - `BUSTER_LOG_LEVEL` – Optional log level (default is `INFO`).
+- `OFAC_API_URL` – HTTP endpoint used to submit validated reports.
 
-3. Start the bot (this repository does not yet include the implementation).
+3. Start the bot and use the `/report` command to file an OFAC report.
 Install dependencies and run the bot:
 
     ```bash

--- a/src/buster/discord_bot.py
+++ b/src/buster/discord_bot.py
@@ -6,6 +6,9 @@ import logging
 import os
 
 import discord
+from discord.ext import commands
+
+from .orchestrator import BusterOrchestrator
 
 logging.basicConfig(
     level=getattr(logging, os.getenv("BUSTER_LOG_LEVEL", "INFO").upper(), logging.INFO),
@@ -33,15 +36,38 @@ def get_credentials() -> tuple[str, str]:
     return token, app_id
 
 
-class BusterBot(discord.Client):
+class BusterBot(commands.Bot):
+    def __init__(self, orchestrator: BusterOrchestrator, *, app_id: str, **kwargs) -> None:
+        intents = kwargs.pop("intents", discord.Intents.default())
+        super().__init__(command_prefix="!", intents=intents, application_id=app_id)
+        self.orchestrator = orchestrator
+
+    async def setup_hook(self) -> None:  # type: ignore[override]
+        @self.tree.command(name="report", description="Compile an OFAC report")
+        async def report(interaction: discord.Interaction) -> None:
+            messages: list[str] = []
+
+            async for msg in interaction.channel.history(limit=20):
+                messages.append(msg.content)
+
+            result = self.orchestrator.handle_report_command(messages)
+            try:
+                self.orchestrator.submit_report(result)
+                await interaction.response.send_message(str(result))
+            except Exception as exc:  # pragma: no cover - errors returned to user
+                await interaction.response.send_message(
+                    f"submission failed: {exc}", ephemeral=True
+                )
+
     async def on_ready(self) -> None:  # type: ignore[override]
         logger.info("connected", extra={"user": str(self.user)})
 
 
 def main() -> None:
-    token, _app_id = get_credentials()
+    token, app_id = get_credentials()
     intents = discord.Intents.default()
-    client = BusterBot(intents=intents)
+    orchestrator = BusterOrchestrator()
+    client = BusterBot(orchestrator, intents=intents, app_id=app_id)
     try:
         client.run(token)
     except Exception:  # pragma: no cover - simple run wrapper

--- a/src/buster/orchestrator.py
+++ b/src/buster/orchestrator.py
@@ -1,8 +1,15 @@
 """Core logic for coordinating report compilation and submission."""
 
+from __future__ import annotations
+
 import logging
+import os
+from typing import Any
+
+import requests
 
 from .compiler.report_compiler import ReportCompiler
+from .validation.data_validation import validate_report
 
 
 logger = logging.getLogger(__name__)
@@ -20,3 +27,16 @@ class BusterOrchestrator:
         result = self.compiler.compile(messages)
         logger.info("report command compiled", extra={"return_value": result})
         return result
+
+    def submit_report(self, report: dict[str, Any]) -> bool:
+        """Send the validated report to the configured OFAC endpoint."""
+        if not validate_report(report):
+            raise ValueError("invalid report")
+        endpoint = os.getenv("OFAC_API_URL")
+        if not endpoint:
+            raise RuntimeError("Missing OFAC_API_URL")
+        logger.info("submitting report", extra={"endpoint": endpoint})
+        response = requests.post(endpoint, json=report, timeout=10)
+        response.raise_for_status()
+        logger.info("report submitted", extra={"status": response.status_code})
+        return response.status_code == 200

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -1,6 +1,10 @@
+import asyncio
 import pytest
+import discord
+from unittest import mock
 
-from buster.discord_bot import get_credentials
+from buster.discord_bot import BusterBot, get_credentials
+from buster.orchestrator import BusterOrchestrator
 
 
 def test_get_credentials_missing_env_raises(monkeypatch):
@@ -16,3 +20,41 @@ def test_get_credentials_returns_tuple(monkeypatch):
     token, app_id = get_credentials()
     assert (token, app_id) == ("tok", "appid")
     assert isinstance(token, str) and isinstance(app_id, str)
+
+
+def test_report_command_invokes_orchestrator(monkeypatch):
+    orchestrator = mock.MagicMock()
+    orchestrator.handle_report_command.return_value = {"messages": ["a", "b"]}
+    orchestrator.submit_report.return_value = True
+    bot = BusterBot(orchestrator, intents=discord.Intents.none(), app_id="1")
+    asyncio.run(bot.setup_hook())
+    cmd = bot.tree.get_command("report")
+
+    async def gen():
+        class Msg:
+            def __init__(self, content: str) -> None:
+                self.content = content
+
+        for text in ["a", "b"]:
+            yield Msg(text)
+
+    interaction = mock.MagicMock()
+    interaction.channel.history = lambda limit=20: gen()
+    interaction.response.send_message = mock.AsyncMock()
+
+    asyncio.run(cmd.callback(interaction))
+    orchestrator.handle_report_command.assert_called_with(["a", "b"])
+    orchestrator.submit_report.assert_called_with({"messages": ["a", "b"]})
+    interaction.response.send_message.assert_called()
+
+
+def test_submit_report_posts(monkeypatch):
+    orchestrator = BusterOrchestrator()
+    monkeypatch.setenv("OFAC_API_URL", "http://example.com")
+    post_mock = mock.MagicMock()
+    response = mock.MagicMock(status_code=200)
+    response.raise_for_status = mock.MagicMock()
+    post_mock.return_value = response
+    monkeypatch.setattr("buster.orchestrator.requests.post", post_mock)
+    assert orchestrator.submit_report({"messages": []}) is True
+    post_mock.assert_called_with("http://example.com", json={"messages": []}, timeout=10)


### PR DESCRIPTION
## Summary
- convert bot to `commands.Bot` and register `/report`
- implement `submit_report` for orchestrator
- allow OFAC endpoint via `OFAC_API_URL`
- document new variable and command
- unit test Discord integration and HTTP submission

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae9ca8fbc8323ba98f5050b4b449f