### PR TITLE
Improve orchestrator report flow

### DIFF
--- a/src/buster/orchestrator.py
+++ b/src/buster/orchestrator.py
@@ -3,6 +3,8 @@
 import logging
 
 from .compiler.report_compiler import ReportCompiler
+from .validation.data_validation import validate_report
+from .best_practices.scoring import score_report
 
 
 logger = logging.getLogger(__name__)
@@ -15,8 +17,22 @@ class BusterOrchestrator:
         self.compiler = ReportCompiler()
 
     def handle_report_command(self, messages: list[str]) -> dict:
-        """Compile a report from messages and return structured data."""
-        logger.info("received report command", extra={"message_count": len(messages)})
-        result = self.compiler.compile(messages)
-        logger.info("report command compiled", extra={"return_value": result})
+        """Compile, validate and score a report from provided messages."""
+        logger.info(
+            "received report command",
+            extra={"message_count": len(messages)},
+        )
+
+        report = self.compiler.compile(messages)
+        logger.info("report compiled", extra={"return_value": report})
+
+        if not validate_report(report):
+            logger.error("report validation failed", extra={"report": report})
+            raise ValueError("report validation failed")
+
+        score = score_report(report)
+        logger.info("report scored", extra={"score": score})
+
+        result = {"report": report, "score": score}
+        logger.info("report command completed", extra={"return_value": result})
         return result

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,4 +1,5 @@
 import importlib
+import pytest
 
 
 def test_orchestrator_import():
@@ -6,6 +7,18 @@ def test_orchestrator_import():
     assert hasattr(module, 'BusterOrchestrator')
 
 
-def test_handle_report_command_returns_messages_dict():
+def test_handle_report_command_valid_flow():
     orchestrator = importlib.import_module('buster.orchestrator').BusterOrchestrator()
-    assert orchestrator.handle_report_command(["a"]) == {"messages": ["a"]}
+    result = orchestrator.handle_report_command(["a"])
+    assert result == {"report": {"messages": ["a"]}, "score": 1}
+
+
+def test_handle_report_command_invalid_data_raises(monkeypatch):
+    orchestrator = importlib.import_module('buster.orchestrator').BusterOrchestrator()
+
+    def bad_compile(_: list[str]) -> dict:
+        return {"bad": True}
+
+    monkeypatch.setattr(orchestrator.compiler, "compile", bad_compile)
+    with pytest.raises(ValueError):
+        orchestrator.handle_report_command(["bad"])


### PR DESCRIPTION
## Summary
- validate and score reports inside `BusterOrchestrator.handle_report_command`
- test success and failure flows for handling report commands

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae9c9e8688323bce562f1bfbc25e2