### PR TITLE
Expand ReportCompiler with evidence fetching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ discord.py>=2.3
 requests>=2.31
 flake8>=7.0
 pytest>=8.2
+httpx>=0.27

--- a/src/buster/compiler/report_compiler.py
+++ b/src/buster/compiler/report_compiler.py
@@ -1,9 +1,43 @@
 """Build report data from messages and linked content."""
 
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+import httpx
+
 
 class ReportCompiler:
     """Fetches evidence and assembles the report payload."""
 
-    def compile(self, messages: list[str]) -> dict:
-        """Return a minimal report structure from the provided messages."""
-        return {"messages": messages}
+    URL_RE = re.compile(r"https?://\S+")
+
+    def fetch_url(self, url: str) -> str:
+        """Return text content from a URL or an error message."""
+        try:
+            response = httpx.get(url, timeout=5)
+            response.raise_for_status()
+            return response.text
+        except Exception as exc:  # pragma: no cover - network failures
+            return f"ERROR: {exc}"  # pragma: no cover
+
+    def compile(self, messages: Iterable[dict]) -> dict:
+        """Return structured report data from message dictionaries."""
+        compiled = []
+        for msg in messages:
+            content = msg.get("content", "")
+            evidence = []
+            for url in self.URL_RE.findall(content):
+                evidence.append({"url": url, "content": self.fetch_url(url)})
+
+            compiled.append(
+                {
+                    "author": msg.get("author"),
+                    "timestamp": msg.get("timestamp"),
+                    "content": content,
+                    "evidence": evidence,
+                }
+            )
+
+        return {"messages": compiled}

--- a/src/buster/orchestrator.py
+++ b/src/buster/orchestrator.py
@@ -14,7 +14,7 @@ class BusterOrchestrator:
     def __init__(self) -> None:
         self.compiler = ReportCompiler()
 
-    def handle_report_command(self, messages: list[str]) -> dict:
+    def handle_report_command(self, messages: list[dict]) -> dict:
         """Compile a report from messages and return structured data."""
         logger.info("received report command", extra={"message_count": len(messages)})
         result = self.compiler.compile(messages)

--- a/src/buster/validation/schema.py
+++ b/src/buster/validation/schema.py
@@ -3,7 +3,29 @@
 REPORT_SCHEMA = {
     "type": "object",
     "properties": {
-        "messages": {"type": "array", "items": {"type": "string"}},
+        "messages": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "author": {"type": "string"},
+                    "timestamp": {"type": "string"},
+                    "content": {"type": "string"},
+                    "evidence": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "url": {"type": "string"},
+                                "content": {"type": "string"},
+                            },
+                            "required": ["url", "content"],
+                        },
+                    },
+                },
+                "required": ["author", "timestamp", "content", "evidence"],
+            },
+        },
     },
     "required": ["messages"],
 }

--- a/tests/test_best_practices.py
+++ b/tests/test_best_practices.py
@@ -9,4 +9,8 @@ def test_best_practices_import():
 
 
 def test_score_report_counts_messages():
-    assert score_report({"messages": ["x", "y"]}) == 2
+    messages = [
+        {"content": "x", "author": "a", "timestamp": "t", "evidence": []},
+        {"content": "y", "author": "b", "timestamp": "t", "evidence": []},
+    ]
+    assert score_report({"messages": messages}) == 2

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,13 +1,44 @@
 import importlib
 
 
+module = importlib.import_module('buster.compiler.report_compiler')
+ReportCompiler = module.ReportCompiler
+
+
 def test_compiler_import():
-    module = importlib.import_module('buster.compiler.report_compiler')
     assert hasattr(module, 'ReportCompiler')
 
 
-def test_compile_returns_messages_dict():
-    compiler = importlib.import_module(
-        'buster.compiler.report_compiler'
-    ).ReportCompiler()
-    assert compiler.compile(["msg"]) == {"messages": ["msg"]}
+def test_compile_fetches_url(monkeypatch):
+    def fake_get(url, timeout=5):
+        class Response:
+            text = 'fetched'
+
+            def raise_for_status(self):
+                pass
+
+        return Response()
+
+    monkeypatch.setattr(module.httpx, 'get', fake_get)
+    compiler = ReportCompiler()
+    messages = [{
+        'content': 'see http://example.com',
+        'author': 'user',
+        'timestamp': 't',
+    }]
+    result = compiler.compile(messages)
+    assert result == {
+        'messages': [{
+            'author': 'user',
+            'timestamp': 't',
+            'content': 'see http://example.com',
+            'evidence': [{'url': 'http://example.com', 'content': 'fetched'}],
+        }]
+    }
+
+
+def test_compile_no_urls():
+    compiler = ReportCompiler()
+    messages = [{'content': 'hello', 'author': 'a', 'timestamp': 't'}]
+    result = compiler.compile(messages)
+    assert result['messages'][0]['evidence'] == []

--- a/tests/test_data_validation.py
+++ b/tests/test_data_validation.py
@@ -10,7 +10,8 @@ def test_validate_report_returns_true_for_valid_data():
     validate_report = importlib.import_module(
         'buster.validation.data_validation'
     ).validate_report
-    assert validate_report({"messages": ["m"]}) is True
+    data = {"messages": [{"author": "a", "timestamp": "t", "content": "m", "evidence": []}]}
+    assert validate_report(data) is True
 
 
 def test_validate_report_returns_false_for_invalid_data():

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -8,4 +8,10 @@ def test_orchestrator_import():
 
 def test_handle_report_command_returns_messages_dict():
     orchestrator = importlib.import_module('buster.orchestrator').BusterOrchestrator()
-    assert orchestrator.handle_report_command(["a"]) == {"messages": ["a"]}
+    messages = [{
+        'content': 'a',
+        'author': 'user',
+        'timestamp': 't',
+    }]
+    result = orchestrator.handle_report_command(messages)
+    assert result['messages'][0]['content'] == 'a'


### PR DESCRIPTION
## Summary
- refine ReportCompiler to collect author, timestamp and linked content
- update schema to include message metadata and fetched evidence
- adjust orchestrator interface to pass message dictionaries
- add httpx requirement
- update tests to cover new behaviour and mocked HTTP calls

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ae9c833388323ac3a55edf1d9c94c