### PR TITLE
Remove legacy report command

### DIFF
--- a/src/buster/orchestrator.py
+++ b/src/buster/orchestrator.py
@@ -22,18 +22,6 @@ class BusterOrchestrator:
     def __init__(self) -> None:
         self.compiler = ReportCompiler()
 
-    def handle_report_command(self, user_id: str, messages: list[str]) -> dict:
-        """Compile a report from messages and return structured data."""
-        logger.info(
-            "received report command",
-            extra={"user_id": user_id, "message_count": len(messages)},
-        )
-        result = self.compiler.compile(messages)
-        logger.info(
-            "report command compiled",
-            extra={"user_id": user_id, "message_count": len(messages)},
-        )
-        
     def handle_report_command(self, messages: list[str]) -> dict:
         """Compile, validate and score a report from provided messages."""
         logger.info(

--- a/src/buster/validation/schema.py
+++ b/src/buster/validation/schema.py
@@ -1,4 +1,6 @@
 """JSON schema definitions for report validation."""
+from __future__ import annotations
+
 REPORT_SCHEMA = {
     "type": "object",
     "properties": {
@@ -28,13 +30,3 @@ REPORT_SCHEMA = {
     },
     "required": ["messages"],
 }
-
-from __future__ import annotations
-
-import json
-from pathlib import Path
-
-SCHEMA_PATH = Path(__file__).resolve().parents[3] / "docs" / "ofac_schema.json"
-
-with SCHEMA_PATH.open() as f:
-    REPORT_SCHEMA: dict = json.load(f)

--- a/tests/test_data_validation.py
+++ b/tests/test_data_validation.py
@@ -1,11 +1,17 @@
 import importlib
 
+
 def _get_validate():
-    return importlib.import_module('buster.validation.data_validation').validate_report
+    return (
+        importlib.import_module("buster.validation.data_validation")
+        .validate_report
+    )
+
 
 def test_data_validation_import():
-    module = importlib.import_module('buster.validation.data_validation')
+    module = importlib.import_module("buster.validation.data_validation")
     assert hasattr(module, 'validate_report')
+
 
 def test_validate_report_returns_true_for_valid_data():
     validate_report = importlib.import_module(
@@ -13,6 +19,7 @@ def test_validate_report_returns_true_for_valid_data():
     ).validate_report
     data = {"messages": [{"author": "a", "timestamp": "t", "content": "m", "evidence": []}]}
     assert validate_report(data) is True
+
 
 def test_validate_report_returns_false_for_wrong_type():
     validate_report = _get_validate()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,17 +1,26 @@
 import importlib
 import pytest
 
+
 def test_orchestrator_import():
     module = importlib.import_module('buster.orchestrator')
     assert hasattr(module, 'BusterOrchestrator')
 
+
 def test_handle_report_command_valid_flow():
     orchestrator = importlib.import_module('buster.orchestrator').BusterOrchestrator()
+    messages = [{"content": "a", "author": "u", "timestamp": "t"}]
+    result = orchestrator.handle_report_command(messages)
+    assert result == {
+        "report": {
+            "messages": [{"author": "u", "timestamp": "t", "content": "a", "evidence": []}]
+        },
+        "score": 1,
+    }
 
-    result = orchestrator.handle_report_command(["a"])
-    assert result == {"report": {"messages": ["a"]}, "score": 1}
 
-
-def test_handle_report_command_invalid_data_raises(monkeypatch):
+def test_handle_report_command_invalid_data_raises():
     orchestrator = importlib.import_module('buster.orchestrator').BusterOrchestrator()
-    assert orchestrator.handle_report_command("u1", ["a"]) == {"messages": ["a"]}
+    messages = [{"content": "a", "timestamp": "t"}]  # missing author
+    with pytest.raises(ValueError):
+        orchestrator.handle_report_command(messages)


### PR DESCRIPTION
## Summary
- delete outdated `handle_report_command` overload
- ensure schema module is valid Python and uses in-file schema
- update orchestrator tests for new method signature
- fix test formatting for flake8 compliance

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af8b9fc008323a5be73adc5561384